### PR TITLE
Spray Painter Gas Pipe Coloring

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/spray_painter.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/spray_painter.yml
@@ -25,10 +25,19 @@
       blue: '#0335FCFF'
       white: '#FFFFFFFF'
       black: '#333333FF'
+      # gas tank colors
+      oxygen: '#2788E8FF'
+      nitrogen: '#D90F0FFF'
+      nitrous oxide: '#F66A6AFF'
+      carbon dioxide: '#4F4F4FFF'
+      water vapor: '#A0A0DAFF'
+      plasma: '#FC32A0FF'
+      tritium: '#17FF0BFF'
+      frezon: '#47CDFFFF'
       # standard atmos pipes
-      waste: '#990000'
-      distro: '#0055cc'
-      air: '#03fcd3'
-      mix: '#947507'
+      waste: '#990000FF'
+      distro: '#0055CCFF'
+      air: '#03FCD3FF'
+      mix: '#947507FF'
   - type: StaticPrice
     price: 40


### PR DESCRIPTION

# Description

The spraypainter now uses colors relating to each gas (minus ammonia but what the fuck are you using ammonia for???)

I feel like this just looks better than adding random colors for each gas type

---

<details><summary><h1>Media</h1></summary>
<p>

<img width="797" height="302" alt="An image displaying all the new pipe colors. I dunno how to explain what they look like. Sorry blind people." src="https://github.com/user-attachments/assets/21a544d6-168a-4688-9818-c487ace1b0e6" />

</p>
</details>

---

This the same as pull [Moffstation #155](https://github.com/moff-station/moff-station-14/pull/155).

---


# Changelog
:cl: JamiMyst
- tweak: handheld spray painters now have pipe-colors for most gases in Atmospherics.
